### PR TITLE
Add a missing color property `normalColor` instead of hard-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Styles for the gesture password view.
 ### textStyle (string)
 Style for the text element in the view.
 
-### circleColor (string)
+### normalColor (string)
 
 Use this color to render the default circle color.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Styles for the gesture password view.
 ### textStyle (string)
 Style for the text element in the view.
 
+### circleColor (string)
+
+Use this color to render the default circle color.
+
 ### rightColor (string)
 
 Use this color to render when status !== 'wrong'.

--- a/source/circle.js
+++ b/source/circle.js
@@ -7,11 +7,11 @@ export default class Circle extends Component {
     }
 
     render() {
-        let {color, fill, x, y, r, inner, outer} = this.props;
+        let {color, normalColor, fill, x, y, r, inner, outer} = this.props;
 
         return (
             <View style={[styles.outer,
-                        {left: x - r, top: y - r, width: 2 * r, height: 2 * r, borderRadius: r},
+                        {left: x - r, top: y - r, width: 2 * r, height: 2 * r, borderRadius: r}, {borderColor: normalColor},
                         fill && {borderColor: color},
                         !outer && {borderWidth: 0}]}>
 

--- a/source/index.js
+++ b/source/index.js
@@ -89,7 +89,7 @@ export default class GesturePassword extends Component {
 
     renderCircles() {
         let array = [], fill, color, inner, outer;
-        let { status, wrongColor, rightColor, innerCircle, outerCircle } = this.props;
+        let { status, normalColor, wrongColor, rightColor, innerCircle, outerCircle } = this.props;
 
         this.state.circles.forEach(function(c, i) {
             fill = c.isActive;
@@ -98,7 +98,7 @@ export default class GesturePassword extends Component {
             outer = !!outerCircle;
 
             array.push(
-                <Circle key={'c_' + i} fill={fill} color={color} x={c.x} y={c.y} r={Radius} inner={inner} outer={outer} />
+                <Circle key={'c_' + i} fill={fill} normalColor={normalColor} color={color} x={c.x} y={c.y} r={Radius} inner={inner} outer={outer} />
             )
         });
 
@@ -270,6 +270,7 @@ export default class GesturePassword extends Component {
 
 GesturePassword.propTypes = {
     message: PropTypes.string,
+    normalColor: PropTypes.string, 
     rightColor: PropTypes.string,
     wrongColor: PropTypes.string,
     status: PropTypes.oneOf(['right', 'wrong', 'normal']),
@@ -284,6 +285,7 @@ GesturePassword.propTypes = {
 
 GesturePassword.defaultProps = {
     message: '',
+    normalColor: '#5FA8FC',
     rightColor: '#5FA8FC',
     wrongColor: '#D93609',
     status: 'normal',


### PR DESCRIPTION
- [x] `normalColor`
- [x] `rightColor`
- [x] `wrongColor`


