### PR TITLE
fix the module requirement for 'PropTypes'

### DIFF
--- a/source/circle.js
+++ b/source/circle.js
@@ -1,5 +1,6 @@
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { StyleSheet, View } from 'react-native'
+import PropTypes from 'prop-types';
 
 export default class Circle extends Component {
     constructor(props) {

--- a/source/index.js
+++ b/source/index.js
@@ -1,5 +1,5 @@
 import * as helper from './helper'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import {
     StyleSheet,
     Dimensions,
@@ -7,6 +7,7 @@ import {
     View,
     Text
 } from 'react-native'
+import PropTypes from 'prop-types';
 import Line from './line'
 import Circle from './circle'
 

--- a/source/line.js
+++ b/source/line.js
@@ -1,6 +1,7 @@
 import { isEquals, getTransform } from './helper'
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
 import { StyleSheet, View } from 'react-native'
+import PropTypes from 'prop-types';
 
 export default class Line extends Component {
     constructor(props) {


### PR DESCRIPTION
From `React@16.0.0` (2017.09.27)，`PropTypes` is removed from core package, as a new package `prop-types`.

https://github.com/facebook/react/blob/master/CHANGELOG.md#removed-deprecations