### PR TITLE
Fix warning assign props to state

### DIFF
--- a/source/line.js
+++ b/source/line.js
@@ -6,7 +6,7 @@ export default class Line extends Component {
     constructor(props) {
         super(props);
 
-        this.state = this.props;
+        this.state = { ...props };
     }
 
     setNativeProps(props) {


### PR DESCRIPTION
fix Warning: "Line": It is not recommended to assign props directly to state because updates to props won't be reflected in state. In most cases, it is better to use props directly.